### PR TITLE
Update ConsoleHandler.php

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -155,8 +155,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     protected function write(array $record)
     {
-        // at this point we've determined for sure that we want to output the record, so use the output's own verbosity
-        $this->output->write((string) $record['formatted'], false, $this->output->getVerbosity());
+        $this->output->write((string) $record['formatted'], false);
     }
 
     /**


### PR DESCRIPTION
The third parameter of `Symfony\Component\Console\Output\OutputInterface::write()` is `$type`; not `$verbosity`. This is intended for distinguishing between normal, raw, and plain output. 

The previous code happens to work in most cases because these constants are similar.

```
interface OutputInterface
{
    const VERBOSITY_QUIET = 0;
    const VERBOSITY_NORMAL = 1;
    const VERBOSITY_VERBOSE = 2;
    const VERBOSITY_VERY_VERBOSE = 3;
    const VERBOSITY_DEBUG = 4;

    const OUTPUT_NORMAL = 0;
    const OUTPUT_RAW = 1;
    const OUTPUT_PLAIN = 2;
```

When VERBOSITY_DEBUG is used, an InvalidArgumentException is thrown with the message `Unknown output type given (4)`.

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8 or 3.2 <!-- see comment below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Deprecations? | yes/no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
